### PR TITLE
Pass ports to the django server

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -20,12 +20,12 @@ server {
 
     location /api/ {
         proxy_pass http://api;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
     }
 
     location /admin/ {
         proxy_pass http://api;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
     }
 
     location /static-files/ {


### PR DESCRIPTION
We need to make sure the port is passed to the api server so when it return links (like images) they can be rendered properly.

Fixes: https://github.com/open-eats/openeats-api/issues/7