### PR TITLE
Comment typo fix

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 # NGINX doesn't let you use ENV vars within the conf file.
 # We use sed to set the env vars we need.
-# Sed replace the API_PORT and NODE_PORT vars.
+# Sed replace the API_PORT vars.
 
 sed -i "s/API_PORT/$API_PORT/g" /etc/nginx/conf.d/default.conf;
 


### PR DESCRIPTION
removing NODE_PORT env var and using location.origin as the default apiHost